### PR TITLE
Make sure to protect certain characters from markdown or HTML

### DIFF
--- a/build.py
+++ b/build.py
@@ -70,7 +70,10 @@ def convert_pod_to_md(tmp_dir: str):
         if "internal" in pod.parent.parts:
             continue
         target = f"docs/{dir_map[pod.parent.name]}/{pod.stem}.md"
-        ps = subprocess.run(["pod2markdown", "--man-url-prefix", "../../man", str(pod), target])
+        ps = subprocess.run(["pod2markdown",
+                             "--html-encode-chars", "1",
+                             "--man-url-prefix", "../../man",
+                             str(pod), target])
         if ps.returncode != 0:
             raise SystemExit(ps.returncode)
 


### PR DESCRIPTION
Characters like '<', '>', '&' are interpreted by markdown or HTML in "funny"
ways.  Fortunately, pod2markdown has exactly the option we need to have that
protection:

> --html-encode-chars
>     A  list  of  characters  to  encode as HTML entities.  Pass a regexp
>     character class, or 1 to mean control  chars,  high-bit  chars,  and
>     "<&>"'".
>
>     See "html_encode_chars" in Pod::Markdown for more information.

Fixes #openssl/openssl#25407
