### PR TITLE
Front page overhaul

### DIFF
--- a/scaffold/index.md
+++ b/scaffold/index.md
@@ -8,11 +8,25 @@ search:
 
 # Home
 
-A good starting point for learning OpenSSL 3.0 is the
-[OpenSSL introduction page](/master/man7/ossl-guide-introduction/). For the underlying key concepts,
-there are the lowlevel [libcrypto](/master/man7/ossl-guide-libcrypto-introduction/) and
-[libssl](/master/man7/ossl-guide-libssl-introduction/) manuals. Notes about migrating existing
-applications to OpenSSL 3.0 are in the [OpenSSL 3.0 Migration Guide](/3.0/man7/migration_guide/).
+A good starting point for learning OpenSSL is the
+[OpenSSL Guide](/master/man7/ossl-guide-introduction/):
+
+* [OpenSSL Guide: An introduction to OpenSSL](/master/man7/ossl-guide-introduction/)
+* [The OpenSSL libraries](/master/man7/ossl-guide-libraries-introduction/)
+  * [libcrypto](/master/man7/ossl-guide-libcrypto-introduction/)
+  * [libssl](/master/man7/ossl-guide-libssl-introduction/)
+* [An introduction to SSL/TLS in OpenSSL](/master/man7/ossl-guide-tls-introduction/)
+  * [Writing a simple blocking TLS client](master/man7/ossl-guide-tls-client-block/)
+  * [Writing a simple nonblocking TLS client](/master/man7/ossl-guide-tls-client-non-block/)
+  * [Writing a simple blocking TLS server](/master/man7/ossl-guide-tls-server-block/)
+* [An introduction to QUIC in OpenSSL](/master/man7/ossl-guide-quic-introduction/)
+  * [Writing a simple blocking QUIC client](/master/man7/ossl-guide-quic-client-block/)
+  * [Writing a simple blocking QUIC server](/master/man7/ossl-guide-quic-server-block/)
+  * [Writing a simple multi-stream QUIC client](/master/man7/ossl-guide-quic-multi-stream/)
+  * [Writing a simple nonblocking QUIC server](/master/man7/ossl-guide-quic-server-non-block/)
+  * [Writing a simple nonblocking QUIC client](/master/man7/ossl-guide-quic-client-non-block/)
+* [Migrating from older OpenSSL versions](/master/man7/ossl-guide-migration/)
+
 
 Information related to the OpenSSL FIPS Validation [FIPS 140-2 validation](fips.md) is also
 available.

--- a/scaffold/index.md
+++ b/scaffold/index.md
@@ -8,25 +8,36 @@ search:
 
 # Home
 
+## OpenSSL Reference
+
+* [`openssl` command line interface](/master/man1/)
+* [OpenSSL Library functions](/master/man3/)
+* [OpenSSL file formats](/master/man5/)
+* [OpenSSL overviews](/master/man7/)
+
+## OpenSSL Guide
+
 A good starting point for learning OpenSSL is the
 [OpenSSL Guide](/master/man7/ossl-guide-introduction/):
 
 * [OpenSSL Guide: An introduction to OpenSSL](/master/man7/ossl-guide-introduction/)
 * [The OpenSSL libraries](/master/man7/ossl-guide-libraries-introduction/)
-  * [libcrypto](/master/man7/ossl-guide-libcrypto-introduction/)
-  * [libssl](/master/man7/ossl-guide-libssl-introduction/)
+    * [libcrypto](/master/man7/ossl-guide-libcrypto-introduction/)
+    * [libssl](/master/man7/ossl-guide-libssl-introduction/)
 * [An introduction to SSL/TLS in OpenSSL](/master/man7/ossl-guide-tls-introduction/)
-  * [Writing a simple blocking TLS client](master/man7/ossl-guide-tls-client-block/)
-  * [Writing a simple nonblocking TLS client](/master/man7/ossl-guide-tls-client-non-block/)
-  * [Writing a simple blocking TLS server](/master/man7/ossl-guide-tls-server-block/)
+    * [Writing a simple blocking TLS client](master/man7/ossl-guide-tls-client-block/)
+    * [Writing a simple nonblocking TLS client](/master/man7/ossl-guide-tls-client-non-block/)
+    * [Writing a simple blocking TLS server](/master/man7/ossl-guide-tls-server-block/)
 * [An introduction to QUIC in OpenSSL](/master/man7/ossl-guide-quic-introduction/)
-  * [Writing a simple blocking QUIC client](/master/man7/ossl-guide-quic-client-block/)
-  * [Writing a simple blocking QUIC server](/master/man7/ossl-guide-quic-server-block/)
-  * [Writing a simple multi-stream QUIC client](/master/man7/ossl-guide-quic-multi-stream/)
-  * [Writing a simple nonblocking QUIC server](/master/man7/ossl-guide-quic-server-non-block/)
-  * [Writing a simple nonblocking QUIC client](/master/man7/ossl-guide-quic-client-non-block/)
+    * [Writing a simple blocking QUIC client](/master/man7/ossl-guide-quic-client-block/)
+    * [Writing a simple blocking QUIC server](/master/man7/ossl-guide-quic-server-block/)
+    * [Writing a simple multi-stream QUIC client](/master/man7/ossl-guide-quic-multi-stream/)
+    * [Writing a simple nonblocking QUIC server](/master/man7/ossl-guide-quic-server-non-block/)
+    * [Writing a simple nonblocking QUIC client](/master/man7/ossl-guide-quic-client-non-block/)
 * [Migrating from older OpenSSL versions](/master/man7/ossl-guide-migration/)
 
+
+## OpenSSL FIPS
 
 Information related to the OpenSSL FIPS Validation [FIPS 140-2 validation](fips.md) is also
 available.


### PR DESCRIPTION
Key points:

1. The old version was very 3.0-focused and we are on 4.0. 
2. Links to docs should (almost) always go to `/master`
3. Finding the Guide content is somewhat complicated. Listing it in table of contents form ought to help.

Potential future changes:

1. Explain man1, man3, man5, man7 structure.
2. Link to the Library homepage.
3. Link to the Project, Corporation and Foundation.
4. Maybe include some getting started advice in addition to the guides.